### PR TITLE
Fix QT emit macro interfering with tbb

### DIFF
--- a/cmd/moonray_gui/CMakeLists.txt
+++ b/cmd/moonray_gui/CMakeLists.txt
@@ -7,6 +7,8 @@ set(CMAKE_AUTOMOC TRUE)
 
 add_executable(${target})
 
+target_compile_definitions(${target} PRIVATE QT_NO_KEYWORDS)
+
 # -----------------------------------------
 # CRT objects
 # color render transform tables are just large float arrays


### PR DESCRIPTION
# ReleaseNote
Compatibility (major, minor, patch, build):  build
Jira ticket: na
Release Notes Comment:  

Special Notes: Including some of the QT headers define an "emit" macro that causes clashes in some of the newer tbb headers which have function definitions called "emit", resulting in a build failure. Setting QT_NO_KEYWORDS makes QT not define those macros.

Look or Scene Setup Change: No


