### PR TITLE
Switch from deprecated tbb::atomic to std::atomic

### DIFF
--- a/cmd/moonray_gui/RenderGui.h
+++ b/cmd/moonray_gui/RenderGui.h
@@ -9,8 +9,6 @@
 #include <mcrt_denoise/denoiser/Denoiser.h>
 #include <moonray/rendering/rndr/rndr.h>
 
-#include <tbb/atomic.h>
-
 #define NUM_TILE_FADE_STEPS  4
 
 namespace moonray_gui {
@@ -119,7 +117,7 @@ private:
     /// The renderering code will strive to render this frame. If it's rendering
     /// a frame with a lower timestamp then we know the frame it's currently
     /// rendering is old.
-    tbb::atomic<uint32_t>   mMasterTimestamp;
+    std::atomic<uint32_t>   mMasterTimestamp;
 
     /// The timestamp of the frame the renderer is currently processing.
     uint32_t                mRenderTimestamp;


### PR DESCRIPTION
# ReleaseNote
Compatibility (major, minor, patch, build): build
Jira ticket: na
Release Notes Comment:

Special Notes: Changes away from tbb::atomic to the std::atomic as it has been deprecated and removed in tbb 2021+

Look or Scene Setup Change: No

