### PR TITLE
Link to dl for imgui's OpenGL3 backend.

### DIFF
--- a/cmd/moonray_gui_v2/CMakeLists.txt
+++ b/cmd/moonray_gui_v2/CMakeLists.txt
@@ -70,7 +70,7 @@ target_sources(${target}
 target_include_directories(${target} PRIVATE ${imgui_SOURCE_DIR})
 
 if (NOT IsDarwinPlatform)
-    set(PlatformSpecificLibs atomic)
+    set(PlatformSpecificLibs atomic dl)
 endif()
 
 target_link_libraries(${target}


### PR DESCRIPTION
moonray_gui_v2 uses the dynamic linker API (dlopen/dlclose/dlerror) from
libdl. The ASWF CI images for 2023–2025 all use GCC 11.2 (per VFX Reference
Platform), but the linker flag --as-needed (the default on modern Linux
distributions) causes libdl to be dropped when it is not listed as a direct
dependency. Previously libdl was pulled in transitively by another linked
library; with the libraries present in these images it is not, so it must be
listed explicitly.

Fixes OpenMoonRay/openmoonray#246

Assisted-by: GitHub Copilot / Sonnet 4.6

Signed-off-by: Jon Lanz <jon.lanz@dreamworks.com>
